### PR TITLE
feat: ability to show/hide grid lines in waterfall

### DIFF
--- a/plugins/plugin-chart-waterfall/src/components/WaterfallChart.tsx
+++ b/plugins/plugin-chart-waterfall/src/components/WaterfallChart.tsx
@@ -63,7 +63,7 @@ export type WaterfallChartProps = {
   onBarClick?: Function;
   width: number;
   data: WaterfallChartData[];
-  showGridLines: boolean;
+  showHorizontalGridLines: boolean;
 };
 
 const Styles = styled.div<WaterfallStylesProps>`
@@ -108,7 +108,7 @@ const WaterfallChart: FC<WaterfallChartProps> = props => {
     yAxisLabelAngle,
     xAxisLabel,
     yAxisLabel,
-    showGridLines,
+    showHorizontalGridLines,
   } = props;
   const rootRef = useRef<HTMLDivElement>(null);
   const [notification, setNotification] = useState<string | null>(null);
@@ -172,7 +172,7 @@ const WaterfallChart: FC<WaterfallChartProps> = props => {
               iconSize={10}
               payload={LEGEND}
             />
-            <CartesianGrid vertical={false} horizontal={showGridLines} />
+            <CartesianGrid vertical={false} horizontal={showHorizontalGridLines} />
             <XAxis dataKey={xAxisDataKey} dy={10} angle={-45} tick={WaterfallTick} interval={0} {...xAxisProps} />
             <YAxis tickFormatter={formatter} {...yAxisProps} />
             <Tooltip content={<WaterfallTooltip formatter={formatter} />} />

--- a/plugins/plugin-chart-waterfall/src/components/WaterfallChart.tsx
+++ b/plugins/plugin-chart-waterfall/src/components/WaterfallChart.tsx
@@ -63,6 +63,7 @@ export type WaterfallChartProps = {
   onBarClick?: Function;
   width: number;
   data: WaterfallChartData[];
+  showGridLines: boolean;
 };
 
 const Styles = styled.div<WaterfallStylesProps>`
@@ -107,6 +108,7 @@ const WaterfallChart: FC<WaterfallChartProps> = props => {
     yAxisLabelAngle,
     xAxisLabel,
     yAxisLabel,
+    showGridLines,
   } = props;
   const rootRef = useRef<HTMLDivElement>(null);
   const [notification, setNotification] = useState<string | null>(null);
@@ -170,7 +172,7 @@ const WaterfallChart: FC<WaterfallChartProps> = props => {
               iconSize={10}
               payload={LEGEND}
             />
-            <CartesianGrid vertical={false} />
+            <CartesianGrid vertical={false} horizontal={showGridLines} />
             <XAxis dataKey={xAxisDataKey} dy={10} angle={-45} tick={WaterfallTick} interval={0} {...xAxisProps} />
             <YAxis tickFormatter={formatter} {...yAxisProps} />
             <Tooltip content={<WaterfallTooltip formatter={formatter} />} />

--- a/plugins/plugin-chart-waterfall/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-waterfall/src/plugin/controlPanel.ts
@@ -128,7 +128,7 @@ export const legendPosition = {
 };
 
 export const showGridLines = {
-  name: 'show-grid-lines',
+  name: 'show_horizontal_grid_lines',
   config: {
     type: 'CheckboxControl',
     label: t('Show Grid Lines'),

--- a/plugins/plugin-chart-waterfall/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-waterfall/src/plugin/controlPanel.ts
@@ -127,6 +127,17 @@ export const legendPosition = {
   },
 };
 
+export const showGridLines = {
+  name: 'show-grid-lines',
+  config: {
+    type: 'CheckboxControl',
+    label: t('Show Grid Lines'),
+    renderTrigger: true,
+    default: false,
+    description: t('Show/Hide grid lines'),
+  },
+};
+
 const config: ControlPanelConfig = {
   controlPanelSections: [
     {
@@ -158,7 +169,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Chart Options'),
       expanded: true,
-      controlSetRows: [[numbersFormat, numbersFormatDigits], [legendPosition]],
+      controlSetRows: [[numbersFormat, numbersFormatDigits], [legendPosition], [showGridLines]],
     },
     {
       label: t('X Axis'),

--- a/plugins/plugin-chart-waterfall/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-waterfall/src/plugin/controlPanel.ts
@@ -127,13 +127,13 @@ export const legendPosition = {
   },
 };
 
-export const showGridLines = {
+export const showHorizontalGridLines = {
   name: 'show_horizontal_grid_lines',
   config: {
     type: 'CheckboxControl',
     label: t('Show Grid Lines'),
     renderTrigger: true,
-    default: false,
+    default: true,
     description: t('Show/Hide grid lines'),
   },
 };
@@ -169,7 +169,7 @@ const config: ControlPanelConfig = {
     {
       label: t('Chart Options'),
       expanded: true,
-      controlSetRows: [[numbersFormat, numbersFormatDigits], [legendPosition], [showGridLines]],
+      controlSetRows: [[numbersFormat, numbersFormatDigits], [legendPosition], [showHorizontalGridLines]],
     },
     {
       label: t('X Axis'),

--- a/plugins/plugin-chart-waterfall/src/plugin/transformProps.ts
+++ b/plugins/plugin-chart-waterfall/src/plugin/transformProps.ts
@@ -37,7 +37,7 @@ type FormData = {
   legendPosition: LegendPosition;
   orderByChange: SortingType;
   useOrderByChange: boolean;
-  showGridLines: boolean;
+  showHorizontalGridLines: boolean;
 };
 
 export default function transformProps(chartProps: ChartProps): WaterfallChartProps {
@@ -51,7 +51,7 @@ export default function transformProps(chartProps: ChartProps): WaterfallChartPr
     legendPosition,
     orderByChange,
     useOrderByChange,
-    showGridLines,
+    showHorizontalGridLines,
   } = formData as FormData;
 
   const valueColumn = metric.label;
@@ -78,7 +78,7 @@ export default function transformProps(chartProps: ChartProps): WaterfallChartPr
     width,
     height,
     legendPosition,
-    showGridLines,
+    showHorizontalGridLines,
     numbersFormat,
     data: resultData,
     onBarClick: () => null,

--- a/plugins/plugin-chart-waterfall/src/plugin/transformProps.ts
+++ b/plugins/plugin-chart-waterfall/src/plugin/transformProps.ts
@@ -37,6 +37,7 @@ type FormData = {
   legendPosition: LegendPosition;
   orderByChange: SortingType;
   useOrderByChange: boolean;
+  showGridLines: boolean;
 };
 
 export default function transformProps(chartProps: ChartProps): WaterfallChartProps {
@@ -50,6 +51,7 @@ export default function transformProps(chartProps: ChartProps): WaterfallChartPr
     legendPosition,
     orderByChange,
     useOrderByChange,
+    showGridLines,
   } = formData as FormData;
 
   const valueColumn = metric.label;
@@ -76,6 +78,7 @@ export default function transformProps(chartProps: ChartProps): WaterfallChartPr
     width,
     height,
     legendPosition,
+    showGridLines,
     numbersFormat,
     data: resultData,
     onBarClick: () => null,

--- a/plugins/plugin-chart-waterfall/test/__mocks__/waterfallProps.ts
+++ b/plugins/plugin-chart-waterfall/test/__mocks__/waterfallProps.ts
@@ -28,6 +28,7 @@ export const legendTop = {
     rowLimit: 100,
     numbersFormat: 'SMART_NUMBER',
     legendPosition: 'top',
+    showGridLines: false,
   },
   height: 400,
   queriesData: [

--- a/plugins/plugin-chart-waterfall/test/__snapshots__/index.test.tsx.snap
+++ b/plugins/plugin-chart-waterfall/test/__snapshots__/index.test.tsx.snap
@@ -39,6 +39,7 @@ Object {
           }
         />,
         <mockConstructor
+          horizontal={false}
           vertical={false}
         />,
         <mockConstructor
@@ -266,6 +267,7 @@ Object {
   ],
   "CartesianGridProps": Array [
     Object {
+      "horizontal": false,
       "vertical": false,
     },
     Object {},


### PR DESCRIPTION
This feature enables the user to 
* show/hide grid lines in the waterfall chart by toggling the corresponding checkbox under the 'Chart Options' settings in the 'Customize' section of the Explore page. 

Previously the horizontal grid line was always on.

<img width="1280" alt="Screenshot 2021-08-05 at 3 53 13 PM" src="https://user-images.githubusercontent.com/45310108/128334791-24f6d183-b3ef-4b2b-8661-3a0faa384b24.png">

Resolves #69 