### PR TITLE
feat: dynamic label for composed chart

### DIFF
--- a/plugins/plugin-chart-composed/src/plugin/configs/colorScheme.ts
+++ b/plugins/plugin-chart-composed/src/plugin/configs/colorScheme.ts
@@ -89,7 +89,6 @@ const getColorSchemeByBreakdown = (i: number): [{ name: string; config: ControlC
   },
 ];
 
-
 const colorSchemeByBreakdown: (
   | [{ name: string; config: ControlConfig<'ColorSchemeControl'> }]
   | [{ name: string; config: ControlConfig<'AdhocFilterControl'> }]
@@ -97,7 +96,7 @@ const colorSchemeByBreakdown: (
 
 for (let i = 0; i < MAX_FORM_CONTROLS; i++) {
   colorSchemeByMetric.push(getColorSchemeBy(i));
-  
+
   colorSchemeByBreakdown.push(getColorSchemeByBreakdown(i));
 }
 

--- a/plugins/plugin-chart-composed/src/plugin/transformProps.ts
+++ b/plugins/plugin-chart-composed/src/plugin/transformProps.ts
@@ -28,6 +28,7 @@ import {
   Data,
   FormData,
   getChartSubType,
+  getLabel,
   processNumbers,
   QueryMode,
   ResultData,
@@ -140,26 +141,6 @@ export default function transformProps(chartProps: ChartProps) {
     );
   }
 
-  const getLabel = (axisLabel: string) => {
-    const moustacheRegexp = new RegExp(/{{(.*?)}}/g);
-    if (moustacheRegexp.test(axisLabel)) {
-      const filterName = axisLabel.replace(/[{}]/g, '').trim();
-      let value = '';
-      if (filterName) {
-        const item = (formData?.extraFilters as any[])?.find(f => f.col === filterName);
-        if (item) {
-          if (item?.op === 'IN') {
-            value = item.val[0];
-          } else {
-            value = item.val;
-          }
-        }
-      }
-      return value;
-    }
-    return axisLabel;
-  };
-
   resultData = processNumbers(resultData, breakdowns, formData.numbersFormat, formData.numbersFormatDigits);
   const result: ComposedChartProps = {
     orderByYColumn: orderByYColumn as SortingType,
@@ -192,7 +173,7 @@ export default function transformProps(chartProps: ChartProps) {
     labelsColor: formData.labelsColor,
     xAxis: {
       interval: formData.xAxisInterval as AxisInterval,
-      label: getLabel(formData.xAxisLabel),
+      label: getLabel(formData, formData.xAxisLabel),
       tickLabelAngle: -Number(formData.xAxisTickLabelAngle),
     },
     scattersStickToBars,
@@ -204,7 +185,7 @@ export default function transformProps(chartProps: ChartProps) {
     yAxis: {
       labelAngle: -Number(formData.yAxisLabelAngle ?? 0),
       labelAngle2: -Number(formData.y2AxisLabelAngle ?? 0),
-      label: getLabel(formData.yAxisLabel),
+      label: getLabel(formData, formData.yAxisLabel),
       tickLabelAngle: -Number(formData.yAxisTickLabelAngle),
       label2: formData.y2AxisLabel,
       tickLabelAngle2: -Number(formData.y2AxisTickLabelAngle),

--- a/plugins/plugin-chart-composed/src/plugin/transformProps.ts
+++ b/plugins/plugin-chart-composed/src/plugin/transformProps.ts
@@ -140,6 +140,26 @@ export default function transformProps(chartProps: ChartProps) {
     );
   }
 
+  const getLabel = (axisLabel: string) => {
+    const moustacheRegexp = new RegExp(/{{(.*?)}}/g);
+    if (moustacheRegexp.test(axisLabel)) {
+      const filterName = axisLabel.replace(/[{}]/g, '').trim();
+      let value = '';
+      if (filterName) {
+        const item = (formData?.extraFilters as any[])?.find(f => f.col === filterName);
+        if (item) {
+          if (item?.op === 'IN') {
+            value = item.val[0];
+          } else {
+            value = item.val;
+          }
+        }
+      }
+      return value;
+    }
+    return axisLabel;
+  };
+
   resultData = processNumbers(resultData, breakdowns, formData.numbersFormat, formData.numbersFormatDigits);
   const result: ComposedChartProps = {
     orderByYColumn: orderByYColumn as SortingType,
@@ -172,7 +192,7 @@ export default function transformProps(chartProps: ChartProps) {
     labelsColor: formData.labelsColor,
     xAxis: {
       interval: formData.xAxisInterval as AxisInterval,
-      label: formData.xAxisLabel,
+      label: getLabel(formData.xAxisLabel),
       tickLabelAngle: -Number(formData.xAxisTickLabelAngle),
     },
     scattersStickToBars,
@@ -184,7 +204,7 @@ export default function transformProps(chartProps: ChartProps) {
     yAxis: {
       labelAngle: -Number(formData.yAxisLabelAngle ?? 0),
       labelAngle2: -Number(formData.y2AxisLabelAngle ?? 0),
-      label: formData.yAxisLabel,
+      label: getLabel(formData.yAxisLabel),
       tickLabelAngle: -Number(formData.yAxisTickLabelAngle),
       label2: formData.y2AxisLabel,
       tickLabelAngle2: -Number(formData.y2AxisTickLabelAngle),

--- a/plugins/plugin-chart-composed/src/plugin/utils.ts
+++ b/plugins/plugin-chart-composed/src/plugin/utils.ts
@@ -247,3 +247,23 @@ export const isQueryMode = (mode: QueryMode) => ({ controls }: ControlPanelsCont
   getQueryMode(controls) === mode;
 export const isAggMode = isQueryMode(QueryMode.aggregate);
 export const isRawMode = isQueryMode(QueryMode.raw);
+
+export const getLabel = (formData: FormData, axisLabel?: string) => {
+  const moustacheRegexp = new RegExp(/{{(.*?)}}/g);
+  if (axisLabel && moustacheRegexp.test(axisLabel)) {
+    const filterName = axisLabel.replace(/[{}]/g, '').trim();
+    let value = '';
+    if (filterName) {
+      const item = (formData?.extraFilters as any[])?.find(f => f.col === filterName);
+      if (item) {
+        if (item?.op === 'IN') {
+          value = item.val.join(', ');
+        } else {
+          value = item.val;
+        }
+      }
+    }
+    return value;
+  }
+  return axisLabel || '';
+};

--- a/plugins/plugin-chart-composed/test/__mocks__/composedProps.ts
+++ b/plugins/plugin-chart-composed/test/__mocks__/composedProps.ts
@@ -645,6 +645,12 @@ const formDataBarsHorizontalLegendTop = {
   timeRange: 'Last week',
   groupby: ['group_type'],
   numbersFormat: 'SMART_NUMBER',
+  xAxisLabel: '{{metric_name_1}}',
+  yAxisLabel: '{{metric_name_2}}',
+  extraFilters: [
+    { col: 'metric_name_1', op: 'IN', val: ['X Axis dynamic label'] },
+    { col: 'metric_name_2', op: 'IN', val: ['Y Axis dynamic label'] },
+  ],
   metrics: [
     {
       expressionType: 'SIMPLE',

--- a/plugins/plugin-chart-composed/test/__snapshots__/index.test.tsx.snap
+++ b/plugins/plugin-chart-composed/test/__snapshots__/index.test.tsx.snap
@@ -1940,7 +1940,7 @@ Object {
             Object {
               "dy": 1,
               "position": "insideBottom",
-              "value": undefined,
+              "value": "X Axis dynamic label",
             }
           }
           tick={[Function]}
@@ -1955,12 +1955,12 @@ Object {
               "dx": -5,
               "dy": 0,
               "position": "insideLeft",
-              "value": undefined,
+              "value": "Y Axis dynamic label",
             }
           }
           orientation="left"
           tick={[Function]}
-          width={1}
+          width={12}
           yAxisId="left"
         />,
         false,
@@ -2275,7 +2275,7 @@ Object {
       "label": Object {
         "dy": 1,
         "position": "insideBottom",
-        "value": undefined,
+        "value": "X Axis dynamic label",
       },
       "tick": [Function],
     },
@@ -2821,7 +2821,7 @@ Object {
             Object {
               "dy": 1,
               "position": "insideBottom",
-              "value": undefined,
+              "value": "X Axis dynamic label",
             }
           }
           tick={[Function]}
@@ -2836,12 +2836,12 @@ Object {
               "dx": -5,
               "dy": 0,
               "position": "insideLeft",
-              "value": undefined,
+              "value": "Y Axis dynamic label",
             }
           }
           orientation="left"
           tick={[Function]}
-          width={1}
+          width={12}
           yAxisId="left"
         />,
         false,
@@ -3034,7 +3034,7 @@ Object {
       "layout": "horizontal",
       "margin": Object {
         "bottom": 17,
-        "left": 4.5,
+        "left": 5,
         "right": 10,
         "top": 15,
       },
@@ -3114,7 +3114,7 @@ Object {
       "label": Object {
         "dy": 1,
         "position": "insideBottom",
-        "value": undefined,
+        "value": "X Axis dynamic label",
       },
       "tick": [Function],
     },
@@ -3130,11 +3130,11 @@ Object {
         "dx": -5,
         "dy": 0,
         "position": "insideLeft",
-        "value": undefined,
+        "value": "Y Axis dynamic label",
       },
       "orientation": "left",
       "tick": [Function],
-      "width": 1,
+      "width": 12,
       "yAxisId": "left",
     },
     Object {},

--- a/stories/plugin-chart-composed/ComposedChartDynamicLabel.stories.tsx
+++ b/stories/plugin-chart-composed/ComposedChartDynamicLabel.stories.tsx
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { ChartProps, supersetTheme, ThemeProvider } from '@superset-ui/core';
+import ComposedChart from '../../plugins/plugin-chart-composed/src/components/ComposedChart';
+import { CHART_SUB_TYPES, CHART_TYPES } from '../../plugins/plugin-chart-composed/src/components/types';
+import transformProps from '../../plugins/plugin-chart-composed/src/plugin/transformProps';
+import { barsHorizontalLegendTop } from '../../plugins/plugin-chart-composed/test/__mocks__/composedProps';
+import { applyCommonLogic, commonConfig } from './utils';
+
+const commonProps = {
+  xAxisTickLabelAngle: '45',
+  yAxisTickLabelAngle: '0',
+  y2AxisTickLabelAngle: '0',
+  useCategoryFormattingGroupBy0: true,
+};
+
+export default {
+  title: 'Plugins/Composed Chart/Combinations',
+  ...commonConfig,
+};
+
+const DynamicLabelTemplate = args => {
+  const chartSubType = args.chartSubType ?? CHART_SUB_TYPES.DEFAULT;
+  if (chartSubType !== CHART_SUB_TYPES.DEFAULT && chartSubType !== CHART_SUB_TYPES.STACKED) {
+    return (
+      <>
+        {`SubType "${args.chartSubType}" is not applied for Bars Chart, please change "chartSubType" property to:`}
+        <li>{CHART_SUB_TYPES.DEFAULT}</li>
+        <li>{CHART_SUB_TYPES.STACKED}</li>
+      </>
+    );
+  }
+  return (
+    <ThemeProvider theme={supersetTheme}>
+      <ComposedChart
+        data={
+          transformProps(({
+            ...barsHorizontalLegendTop,
+            formData: {
+              ...barsHorizontalLegendTop.formData,
+              useCategoryFormattingGroupBy0: args.useCategoryFormattingGroupBy0,
+            },
+            queriesData: args.queriesData,
+          } as unknown) as ChartProps).data
+        }
+        {...applyCommonLogic(args)}
+        chartType={CHART_TYPES.BAR_CHART}
+        chartSubType={chartSubType}
+      />
+    </ThemeProvider>
+  );
+};
+
+export const DynamicLabels = DynamicLabelTemplate.bind({});
+const tProp = transformProps((barsHorizontalLegendTop as unknown) as ChartProps);
+DynamicLabels.args = {
+  ...commonProps,
+  ...tProp,
+  queriesData: barsHorizontalLegendTop.queriesData,
+  chartSubType: CHART_SUB_TYPES.DEFAULT,
+  xAxisLabel: tProp.xAxis.label,
+  yAxisLabel: tProp.yAxis.label,
+};


### PR DESCRIPTION
Upon selecting a dependent filter option for a composed chart, now the user can choose to display the axis labels with the selected value dynamically. 

**Working:**
In order to achieve this functionality, the filter field name should be provided in the axis label field in chart explore page within a moustache syntax as shown below:

![Screenshot 2021-10-13 at 1 28 55 PM](https://user-images.githubusercontent.com/45310108/137092509-2f8c8e34-0098-49cd-a909-cd3e8432ebe2.png)

**Result:**

![dynamic-label](https://user-images.githubusercontent.com/45310108/137092365-736afed3-e4f3-4fe3-a5ca-fa9178d5f4d2.gif)

This is available for both X and Y axis.

Closes #84 
