### PR TITLE
fix: Issue with bubble chart not working in superset 1.4

### DIFF
--- a/plugins/plugin-chart-bubble/src/BubbleChart.tsx
+++ b/plugins/plugin-chart-bubble/src/BubbleChart.tsx
@@ -242,7 +242,7 @@ const BubbleChart: FC<BubbleChartProps> = props => {
               xAxis={xAxis}
               yAxis={yAxis}
               zAxis={zAxis}
-              colorScheme={colorScheme}
+              colorFn={colorFn}
             />
           }
         />

--- a/plugins/plugin-chart-bubble/src/BubbleTooltip.tsx
+++ b/plugins/plugin-chart-bubble/src/BubbleTooltip.tsx
@@ -42,7 +42,7 @@ type BubbleChartTooltipProps = TooltipProps & {
   xAxis: string;
   yAxis: string;
   zAxis: string;
-  colorScheme: string;
+  colorFn: Function;
 };
 
 const BubbleTooltip: FC<BubbleChartTooltipProps> = ({
@@ -54,13 +54,13 @@ const BubbleTooltip: FC<BubbleChartTooltipProps> = ({
   yAxis,
   zAxis,
   series,
-  colorScheme,
+  colorFn,
 }) => {
   if (active) {
     const firstPayload: Payload = payload?.[0]?.payload;
     const formatter = getNumberFormatter(numbersFormat);
     let name = firstPayload[entity];
-    const color = CategoricalColorNamespace.getScale(colorScheme)(firstPayload[series] as string);
+    const color = colorFn(firstPayload[series] as string);
 
     if (series) {
       name = `${name} (${firstPayload[series]})`;

--- a/plugins/plugin-chart-bubble/src/plugin/controlPanel.ts
+++ b/plugins/plugin-chart-bubble/src/plugin/controlPanel.ts
@@ -226,7 +226,7 @@ const config: ControlPanelConfig = {
       label: t('Chart Options'),
       expanded: true,
       controlSetRows: [
-        ['color_scheme', 'label_colors'],
+        ['color_scheme'],
         [numbersFormat, numbersFormatDigits],
         [showGridLines],
         [legendPosition],


### PR DESCRIPTION
Superset 1.4 no longer supports the `label_colors` control for bubble chart. This was removed in order
to fix the issue.


https://user-images.githubusercontent.com/45310108/149318616-7c78069b-8c38-4288-ae77-3213b7ba58ec.mov

